### PR TITLE
feat: Support custom composable markers on Android and glyphText on iOS

### DIFF
--- a/kmp-maps/core/src/androidMain/kotlin/com/swmansion/kmpmaps/core/Map.kt
+++ b/kmp-maps/core/src/androidMain/kotlin/com/swmansion/kmpmaps/core/Map.kt
@@ -24,6 +24,7 @@ import com.google.maps.android.compose.GoogleMap
 import com.google.maps.android.compose.MapEffect
 import com.google.maps.android.compose.MapsComposeExperimentalApi
 import com.google.maps.android.compose.Marker
+import com.google.maps.android.compose.MarkerComposable
 import com.google.maps.android.compose.Polygon
 import com.google.maps.android.compose.Polyline
 import com.google.maps.android.compose.rememberCameraPositionState
@@ -146,18 +147,36 @@ public actual fun Map(
         }
 
         markers.forEach { marker ->
-            Marker(
-                state = marker.toGoogleMapsMarkerState(),
-                title = marker.title,
-                anchor = marker.androidMarkerOptions.anchor.toOffset(),
-                draggable = marker.androidMarkerOptions.draggable,
-                snippet = marker.androidMarkerOptions.snippet,
-                zIndex = marker.androidMarkerOptions.zIndex ?: 0.0f,
-                onClick = {
-                    onMarkerClick?.invoke(marker)
-                    onMarkerClick == null
-                },
-            )
+            if (marker.content != null) {
+                // Use custom composable marker
+                MarkerComposable(
+                    state = marker.toGoogleMapsMarkerState(),
+                    title = marker.title,
+                    anchor = marker.androidMarkerOptions.anchor.toOffset(),
+                    draggable = marker.androidMarkerOptions.draggable,
+                    snippet = marker.androidMarkerOptions.snippet,
+                    zIndex = marker.androidMarkerOptions.zIndex ?: 0.0f,
+                    onClick = {
+                        onMarkerClick?.invoke(marker)
+                        onMarkerClick == null
+                    },
+                    content = marker.content
+                )
+            } else {
+                // Use standard marker
+                Marker(
+                    state = marker.toGoogleMapsMarkerState(),
+                    title = marker.title,
+                    anchor = marker.androidMarkerOptions.anchor.toOffset(),
+                    draggable = marker.androidMarkerOptions.draggable,
+                    snippet = marker.androidMarkerOptions.snippet,
+                    zIndex = marker.androidMarkerOptions.zIndex ?: 0.0f,
+                    onClick = {
+                        onMarkerClick?.invoke(marker)
+                        onMarkerClick == null
+                    },
+                )
+            }
         }
 
         circles.forEach { circle ->

--- a/kmp-maps/core/src/commonMain/kotlin/com/swmansion/kmpmaps/core/IosMapTypes.kt
+++ b/kmp-maps/core/src/commonMain/kotlin/com/swmansion/kmpmaps/core/IosMapTypes.kt
@@ -43,8 +43,12 @@ public data class IosUISettings(
  * iOS-specific options for customizing a marker.
  *
  * @property tintColor The tint color for the marker (Apple Maps only)
+ * @property glyphText Custom text/emoji to display on the marker (Apple Maps only, iOS 11+)
  */
-public data class IosMarkerOptions(val tintColor: Color? = null)
+public data class IosMarkerOptions(
+    val tintColor: Color? = null,
+    val glyphText: String? = null
+)
 
 /**
  * iOS-specific options for the camera position and orientation of the map.

--- a/kmp-maps/core/src/commonMain/kotlin/com/swmansion/kmpmaps/core/MapTypes.kt
+++ b/kmp-maps/core/src/commonMain/kotlin/com/swmansion/kmpmaps/core/MapTypes.kt
@@ -1,5 +1,6 @@
 package com.swmansion.kmpmaps.core
 
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 
 /**
@@ -68,12 +69,16 @@ public data class MapUISettings(
  * @property title The title text displayed when the marker is tapped
  * @property androidMarkerOptions Android-specific options for customizing a marker
  * @property iosMarkerOptions iOS-specific options for customizing a marker
+ * @property content Optional composable content for custom marker appearance. When provided,
+ *   this will render a custom composable as the marker instead of the default marker icon.
+ *   Note: Custom composable markers are currently only supported on Android.
  */
 public data class Marker(
     val coordinates: Coordinates,
     val title: String? = "No title was provided",
     val androidMarkerOptions: AndroidMarkerOptions = AndroidMarkerOptions(),
     val iosMarkerOptions: IosMarkerOptions? = null,
+    val content: (@Composable () -> Unit)? = null,
 )
 
 /**

--- a/kmp-maps/core/src/iosMain/kotlin/com/swmansion/kmpmaps/core/MapDelegate.kt
+++ b/kmp-maps/core/src/iosMain/kotlin/com/swmansion/kmpmaps/core/MapDelegate.kt
@@ -143,6 +143,29 @@ internal class MapDelegate(
         if (viewForAnnotation is MKUserLocation) return null
         val point = viewForAnnotation as? MKPointAnnotation ?: return null
 
+        val marker = markerMapping[point]
+        if (marker != null) {
+            val reuseId = "kmp_custom_marker"
+            val view =
+                mapView.dequeueReusableAnnotationViewWithIdentifier(reuseId) as? MKMarkerAnnotationView
+                    ?: MKMarkerAnnotationView(annotation = viewForAnnotation, reuseIdentifier = reuseId)
+
+            view.annotation = viewForAnnotation
+            view.canShowCallout = true
+
+            // Apply custom styling
+            marker.iosMarkerOptions?.let { options ->
+                options.tintColor?.let { color ->
+                    view.markerTintColor = color.toAppleMapsColor()
+                }
+                options.glyphText?.let { text ->
+                    view.glyphText = text
+                }
+            }
+
+            return view
+        }
+
         val style = geoJsonPointStyles[point] ?: return null
         val reuseId = "kmp_geojson_marker"
 


### PR DESCRIPTION
 Add support for custom marker rendering on both platforms:

  Android:
  - Add optional 'content' parameter to Marker data class
  - Use MarkerComposable when content is provided
  - Fall back to standard Marker when content is null
  - Preserve all marker options (anchor, draggable, snippet, zIndex, onClick)

  iOS:
  - Add glyphText parameter to IosMarkerOptions for custom text/emoji display
  - Update MapDelegate.viewForAnnotation to handle custom markers
  - Use MKMarkerAnnotationView with markerTintColor and glyphText properties
  - Maintain backward compatibility with existing marker API

  This enables developers to create rich, branded map markers with category
  icons, emojis, or custom UI while maintaining cross-platform consistency.