### PR TITLE
fix: Add specific target for build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
     branches: [main]
 jobs:
   build:
-    runs-on: self-hosted
+    runs-on: [self-hosted, macOS, ARM64]
     steps:
       - uses: actions/checkout@v5
       - run: ./gradlew build -x lint -x test


### PR DESCRIPTION
The problem with the current pipeline was that Intel's runner was running, and our current runner is on ARM64.
We have to delete Intel's runner.

<img width="830" height="196" alt="intel_runner" src="https://github.com/user-attachments/assets/743e4570-030e-46e1-ad4b-de734f6d37a2" />
