### PR TITLE
Update self-hosted options

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   build-docs:
-    runs-on: self-hosted
+    runs-on: [self-hosted, macOS, ARM64]
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -36,7 +36,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: self-hosted
+    runs-on: [self-hosted, macOS, ARM64]
     needs: build-docs
     steps:
       - name: Deploy to GitHub Pages

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 jobs:
   publish:
-    runs-on: self-hosted
+    runs-on: [self-hosted, macOS, ARM64]
     steps:
       - uses: actions/checkout@v5
       - run: ./gradlew publishToMavenCentral


### PR DESCRIPTION
Necessary adjustments to resolve a blocker in the release pipeline. Without this fix, version 0.9.0 cannot be successfully published to Maven Central.