### PR TITLE
fix(ios): propagate bearing and viewing angle in CameraPosition

### DIFF
--- a/kmp-maps/google-maps/src/iosMain/kotlin/com/swmansion/kmpmaps/googlemaps/MapDelegate.kt
+++ b/kmp-maps/google-maps/src/iosMain/kotlin/com/swmansion/kmpmaps/googlemaps/MapDelegate.kt
@@ -15,11 +15,11 @@ import cocoapods.Google_Maps_iOS_Utils.GMUClusterManager
 import com.swmansion.kmpmaps.core.CameraPosition
 import com.swmansion.kmpmaps.core.Circle
 import com.swmansion.kmpmaps.core.Coordinates
+import com.swmansion.kmpmaps.core.IosCameraPosition
 import com.swmansion.kmpmaps.core.Marker
 import com.swmansion.kmpmaps.core.Polygon
 import com.swmansion.kmpmaps.core.Polyline
 import com.swmansion.kmpmaps.core.getId
-import com.swmansion.kmpmaps.core.IosCameraPosition
 import kotlinx.cinterop.CValue
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.ObjCSignatureOverride
@@ -64,10 +64,11 @@ internal class MapDelegate(
                         coordinates = Coordinates(latitude = latitude, longitude = longitude),
                         zoom = didChangeCameraPosition.zoom(),
                         bounds = visibleBounds,
-                        iosCameraPosition = IosCameraPosition(
-                            gmsBearing = didChangeCameraPosition.bearing().toFloat(),
-                            gmsViewingAngle = didChangeCameraPosition.viewingAngle().toFloat()
-                        )
+                        iosCameraPosition =
+                            IosCameraPosition(
+                                gmsBearing = didChangeCameraPosition.bearing().toFloat(),
+                                gmsViewingAngle = didChangeCameraPosition.viewingAngle().toFloat(),
+                            ),
                     )
                 it(cameraPosition)
             }


### PR DESCRIPTION
## Summary
This PR fixes an issue on iOS where the map's **bearing** and **viewing angle (tilt)** were not being correctly propagated to the common `CameraPosition` object during map movements.

## Problem
Currently, when the map is manually moved or rotated on iOS, the `MapDelegate` only captures the coordinates and zoom level. This results in the common code losing track of the camera's orientation and tilt.

## Changes
- [x] Updated `MapDelegate.kt` (iOS) to extract `bearing` and `viewingAngle` from the `GMSCameraPosition` object.
- [x] Corrected the mapping to populate the `iosCameraPosition` field within the common `CameraPosition` structure.
