### PR TITLE
Remove deprecated property from example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ fun MyMapScreen() {
             Marker(
                 coordinates = Coordinates(latitude = 50.0486, longitude = 19.9654),
                 title = "Software Mansion",
-                androidSnippet = "Software house"
             )
         ),
         onMarkerClick = { marker ->


### PR DESCRIPTION
`com.swmansion.kmpmaps.core.Marker.androidSnippet` property seems to have been removed in 7a1fcd8c54c147664c7aff1010fb055de0196177. 