### PR TITLE
Patch - Add optional stable Marker.id + Android marker rotation (animated markers)

### DIFF
--- a/kmp-maps/core/src/androidMain/kotlin/com/swmansion/kmpmaps/core/Map.kt
+++ b/kmp-maps/core/src/androidMain/kotlin/com/swmansion/kmpmaps/core/Map.kt
@@ -191,7 +191,7 @@ public actual fun Map(
                 )
             } else {
                 markers.forEach { marker ->
-                    key(marker.getId(), marker.contentId) {
+                    key(marker.getId()) {
                         val markerState =
                             remember(marker.getId()) {
                                 MarkerState(marker.coordinates.toGoogleMapsLatLng())
@@ -216,7 +216,13 @@ public actual fun Map(
                         }
 
                         if (content != null) {
+                            // Re-render the cached marker bitmap in place whenever the visual
+                            // content changes (its [contentId]) — WITHOUT changing the marker's
+                            // identity ([getId]). This lets a stable-id marker update its glyph
+                            // (e.g. a driving puck's baked heading) without being disposed and
+                            // recreated, which is what caused flicker on moving markers.
                             MarkerComposable(
+                                marker.contentId ?: marker.getId(),
                                 state = markerState,
                                 title = marker.title,
                                 anchor = marker.androidMarkerOptions.anchor.toOffset(),

--- a/kmp-maps/core/src/androidMain/kotlin/com/swmansion/kmpmaps/core/Map.kt
+++ b/kmp-maps/core/src/androidMain/kotlin/com/swmansion/kmpmaps/core/Map.kt
@@ -229,6 +229,8 @@ public actual fun Map(
                                 draggable = marker.androidMarkerOptions.draggable,
                                 snippet = marker.androidMarkerOptions.snippet,
                                 zIndex = marker.androidMarkerOptions.zIndex ?: 0.0f,
+                                rotation = marker.androidMarkerOptions.rotation ?: 0.0f,
+                                flat = marker.androidMarkerOptions.flat,
                                 onClick = {
                                     onMarkerClick?.invoke(marker)
                                     onMarkerClick == null
@@ -243,6 +245,8 @@ public actual fun Map(
                                 draggable = marker.androidMarkerOptions.draggable,
                                 snippet = marker.androidMarkerOptions.snippet,
                                 zIndex = marker.androidMarkerOptions.zIndex ?: 0.0f,
+                                rotation = marker.androidMarkerOptions.rotation ?: 0.0f,
+                                flat = marker.androidMarkerOptions.flat,
                                 onClick = {
                                     onMarkerClick?.invoke(marker)
                                     onMarkerClick == null

--- a/kmp-maps/core/src/commonMain/kotlin/com/swmansion/kmpmaps/core/AndroidMapTypes.kt
+++ b/kmp-maps/core/src/commonMain/kotlin/com/swmansion/kmpmaps/core/AndroidMapTypes.kt
@@ -41,6 +41,11 @@ public data class AndroidUISettings(
  * @property draggable Whether the marker can be dragged by the user
  * @property snippet Additional text displayed below the title
  * @property zIndex The z-index for layering markers
+ * @property rotation The rotation of the marker in degrees, clockwise. Combined with a stable
+ *   [Marker.id] this rotates a marker in place (e.g. a driving puck turning to its heading)
+ *   without re-rendering its bitmap. `null` leaves the marker unrotated.
+ * @property flat When `true` the marker is drawn flat against the map so its [rotation] is
+ *   relative to north and it respects the map's tilt/rotation (billboard behaviour when `false`).
  *
  * Note: In the current Android implementation, draggability is only supported when
  * [ClusterSettings.enabled] is set to `false`.
@@ -51,6 +56,8 @@ public data class AndroidMarkerOptions(
     val draggable: Boolean = false,
     val snippet: String? = null,
     val zIndex: Float? = null,
+    val rotation: Float? = null,
+    val flat: Boolean = false,
 )
 
 /**

--- a/kmp-maps/core/src/commonMain/kotlin/com/swmansion/kmpmaps/core/MapTypes.kt
+++ b/kmp-maps/core/src/commonMain/kotlin/com/swmansion/kmpmaps/core/MapTypes.kt
@@ -122,11 +122,24 @@ public data class Marker(
     val androidMarkerOptions: AndroidMarkerOptions = AndroidMarkerOptions(),
     val iosMarkerOptions: IosMarkerOptions? = null,
     val contentId: String? = null,
+    val id: String? = null,
 )
 
-/** @suppress */
+/**
+ * Stable identity used to key the marker in the Compose tree and native caches.
+ *
+ * When [Marker.id] is provided it is used verbatim, so a marker that only changes its
+ * [Marker.coordinates] keeps the same identity across recompositions — the marker is
+ * repositioned in place instead of being disposed and recreated (which causes flicker on
+ * markers that move every frame, e.g. a live driving puck).
+ *
+ * When [Marker.id] is null it falls back to the structural [hashCode], preserving the
+ * previous behaviour for callers that do not opt in.
+ *
+ * @suppress
+ */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-public fun Marker.getId(): String = "marker_${hashCode()}"
+public fun Marker.getId(): String = id?.let { "marker_$it" } ?: "marker_${hashCode()}"
 
 /**
  * Represents a circle overlay on the map.


### PR DESCRIPTION
## Problem                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                    
  Markers are keyed in the Compose tree (and native caches) by `Marker.getId()`, which is                                                                                                                                                                                                                           
  `"marker_${hashCode()}"`. Because `Marker` is a `data class`, its `hashCode()` includes                                                                                                                                                                                                                           
  `coordinates`, so a marker that changes position gets a **new id every move**. The                                                                                                                                                                                                                                
  `key(marker.getId(), …)` block around each marker is therefore disposed and recreated on                                                                                                                                                                                                                          
  every position change — a marker that moves every frame (e.g. a live "driving puck" /                                                                                                                                                                                                                             
  vehicle follower) is torn down and rebuilt continuously, which flickers.                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                    
  The Android renderer already has a `LaunchedEffect(marker.coordinates)` that repositions                                                                                                                                                                                                                          
  `MarkerState.position` in place, but it never survives because the surrounding `key(...)` churns.                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                    
  ## Change                                                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                    
  **1. Optional stable `Marker.id` (commonMain).** A new `val id: String? = null` on `Marker`.                                                                                                                                                                                                                      
  `getId()` uses it when present, else falls back to the previous `hashCode` id:                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                    
  ```kotlin                                                                                                                                                                                                                                                                                                         
  public fun Marker.getId(): String = id?.let { "marker_$it" } ?: "marker_${hashCode()}"                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                    
  When a caller sets a stable id, a marker that only changes coordinates keeps the same                                                                                                                                                                                                                             
  identity, so it is repositioned in place (via the existing LaunchedEffect) instead of                                                                                                                                                                                                                             
  being disposed/recreated. id == null is 100% backward-compatible.                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                    
  On Android the outer key no longer needs contentId (it was redundant with the hashCode id);                                                                                                                                                                                                                       
  instead contentId is passed as the MarkerComposable snapshot key, so the cached bitmap                                                                                                                                                                                                                            
  re-renders in place when the visual content changes without changing marker identity.                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                    
  2. Android marker rotation + flat (AndroidMarkerOptions). Forwarded to the                                                                                                                                                                                                                                        
  underlying maps-compose Marker/MarkerComposable. Combined with a stable id, a marker                                                                                                                                                                                                                              
  can rotate in place (a puck turning to its GPS heading) from a single bitmap instead of                                                                                                                                                                                                                           
  baking every heading into a separate cached bitmap. flat = true makes rotation relative                                                                                                                                                                                                                           
  to north and respects map tilt.
  
  Compatibility                                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                    
  - Both additions are optional with defaults that reproduce today's behaviour exactly.                                                                                                                                                                                                                             
  - No public API removed or changed in signature (new fields appended).                                                                                                                                                                                                                                            
  - Verified :kmp-maps:core:compileReleaseKotlinAndroid on main.                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                    
  Notes                                                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                    
  The iOS/JVM renderers already route through getId(), so they inherit the stable identity.                                                                                                                                                                                                                         
  Rotation is wired for Android only in this PR; happy to extend to iOS in a follow-up.                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                    
  We're using this in production (a community parking app with a live driving puck): with a                                                                                                                                                                                                                         
  stable id + native rotation the moving marker no longer flickers and map pans stay smooth.                                                                                                                                                                                                                        
  We also have a follow-up building on this (LiveMarker: position/rotation as observable                                                                                                                                                                                                                            
  State so a continuously-moving marker updates entirely off the recomposition path + native                                                                                                                                                                                                                        
  glide between fixes) — happy to open it if there's interest.