### PR TITLE
Expose minClusterSize in ClusterSettings

### DIFF
--- a/kmp-maps/core/src/androidMain/kotlin/com/swmansion/kmpmaps/core/Map.kt
+++ b/kmp-maps/core/src/androidMain/kotlin/com/swmansion/kmpmaps/core/Map.kt
@@ -28,6 +28,7 @@ import com.google.maps.android.compose.MarkerComposable
 import com.google.maps.android.compose.MarkerState
 import com.google.maps.android.compose.Polygon
 import com.google.maps.android.compose.Polyline
+import com.google.maps.android.clustering.view.DefaultClusterRenderer
 import com.google.maps.android.compose.clustering.Clustering
 import com.google.maps.android.compose.rememberCameraPositionState
 import com.google.maps.android.data.Layer
@@ -187,6 +188,14 @@ public actual fun Map(
                         customMarkerContent[clusterItem.marker.contentId]?.invoke(
                             clusterItem.marker
                         ) ?: DefaultPin(clusterItem.marker)
+                    },
+                    // The renderer decides how many items make a cluster, and its own default is 4,
+                    // so smaller groups are silently drawn as separate markers. Reaching it through
+                    // this hook is the only way to say otherwise.
+                    onClusterManager = { manager ->
+                        (manager.renderer as? DefaultClusterRenderer<MarkerClusterItem>)
+                            ?.takeIf { it.minClusterSize != clusterSettings.minClusterSize }
+                            ?.minClusterSize = clusterSettings.minClusterSize
                     },
                 )
             } else {

--- a/kmp-maps/core/src/commonMain/kotlin/com/swmansion/kmpmaps/core/MapTypes.kt
+++ b/kmp-maps/core/src/commonMain/kotlin/com/swmansion/kmpmaps/core/MapTypes.kt
@@ -247,13 +247,26 @@ public data class Cluster(val coordinates: Coordinates, val size: Int, val items
  *   `false` to allow the default platform behavior
  * @property clusterContent Optional Composable to render custom cluster UI
  * @property webClusterContent Optional function to render custom cluster UI as HTML string
+ * @property minClusterSize How many items have to fall together before they are drawn as a cluster
+ *   rather than as separate markers. Android only: its renderer defaults to
+ *   [DEFAULT_MIN_CLUSTER_SIZE], while iOS and the web already group from two, so lowering this is
+ *   what makes the three behave alike.
  */
 public data class ClusterSettings(
     val enabled: Boolean = false,
     val onClusterClick: ((Cluster) -> Boolean)? = null,
     val clusterContent: (@Composable (Cluster) -> Unit)? = null,
     val webClusterContent: ((Cluster) -> String)? = null,
+    val minClusterSize: Int = DEFAULT_MIN_CLUSTER_SIZE,
 )
+
+/**
+ * Android's own default, kept so that setting nothing behaves exactly as it did before this option
+ * existed. Note that the platforms do not otherwise agree: MapKit on iOS and the web clusterer both
+ * group from two items, so leaving this at the default gives Android visibly fewer clusters than
+ * the same data produces elsewhere.
+ */
+public const val DEFAULT_MIN_CLUSTER_SIZE: Int = 4
 
 internal object ColorSerializer : KSerializer<Color> {
     override val descriptor = PrimitiveSerialDescriptor("Color", PrimitiveKind.INT)


### PR DESCRIPTION
Small PR to expose minClusterSize. 

Currently the map defaults to a cluster minimum of 4, but offers no way to change that.

For example of the pain point, I have a map here with 2 pins in Denver and 2 pins in Atlanta. Right now the pins are clickable, but you cant select specific ones from either location. With this kind of use case, you'd want to set your clustering to a minimum of 2 so that the user can zone in on a specific city anytime theres at least 2 pins:
<img width="237" height="231" alt="Screenshot 2026-08-05 at 10 47 08 PM" src="https://github.com/user-attachments/assets/dd42fa24-f344-4965-9638-4d01c1bd0088" />