### PR TITLE
fix(android): prevent native info window from appearing on custom mar…

### DIFF
--- a/kmp-maps/core/src/androidMain/kotlin/com/swmansion/kmpmaps/core/Map.kt
+++ b/kmp-maps/core/src/androidMain/kotlin/com/swmansion/kmpmaps/core/Map.kt
@@ -174,7 +174,7 @@ public actual fun Map(
                     },
                     onClusterItemClick = { clusterItem ->
                         onMarkerClick?.invoke(clusterItem.marker)
-                        onMarkerClick == null
+                        true
                     },
                     clusterContent = { androidCluster ->
                         if (clusterSettings.clusterContent != null) {
@@ -225,7 +225,7 @@ public actual fun Map(
                                 zIndex = marker.androidMarkerOptions.zIndex ?: 0.0f,
                                 onClick = {
                                     onMarkerClick?.invoke(marker)
-                                    onMarkerClick == null
+                                    true
                                 },
                                 content = { content(marker) },
                             )


### PR DESCRIPTION
…ker tap

MarkerComposable and onClusterItemClick both returned `onMarkerClick == null` from their onClick lambdas. In maps-compose, returning false means the click is not consumed and the default info window is shown. Since `onMarkerClick == null` evaluates to false whenever a handler is set, the info window always appeared when using customMarkerContent — the opposite of the intended behavior.

Return true unconditionally in both the MarkerComposable and clustering paths so the click is consumed and the native info window is suppressed. Custom marker content owns the full visual representation and has no use for the native overlay. The standard Marker path (no custom content) is unchanged.

Fixes #174